### PR TITLE
Attempted addition of custom commands to be stored in mongo

### DIFF
--- a/mongo_fs.js
+++ b/mongo_fs.js
@@ -2,11 +2,13 @@ const assert = require('assert');
 const mongodb = require('mongodb');
 
 let collection;
+let commandCollection;
 let fs;
 
 const url = 'mongodb://mongo:27017';
 const configDbName = process.env.CONFIG_DB || 'pbot_development';
 const introSoundCollection = 'pbot_intro_sounds';
+const commandSoundCollection = 'pbot_command_sounds';
 
 const client = new mongodb.MongoClient(url);
 
@@ -16,6 +18,7 @@ client.connect((err) =>
 
     const db = client.db(configDbName);
     collection = db.collection(introSoundCollection);
+    commandCollection = db.collection(commandSoundCollection);
     fs = new mongodb.GridFSBucket(db);
 });
 
@@ -38,6 +41,19 @@ module.exports.getSound = function getSound(soundId)
     if (fs)
     {
         return fs.openDownloadStream(mongodb.ObjectId(soundId));
+    }
+
+    return null;
+};
+
+module.exports.getCommand = function getCommand(commandText)
+{
+    if (fs)
+    {
+        return commandCollection.find({
+            commandText: commandText,
+            enabled: true,
+        }).toArray();
     }
 
     return null;

--- a/pbot.js
+++ b/pbot.js
@@ -138,8 +138,24 @@ client.on('message', (message) =>
         console.log(`Got command string '!${command}' from user ${author.id}`);
 
         const audioCommand = audioCommands.find(c => c.command === command);
+        const isMongoCommand = false;
 
-        if (audioCommand) console.log(`Found audio command for !${command}`);
+        if (audioCommand)
+        {
+            console.log(`Found audio command for !${command}`);
+        }
+        else
+        {
+            mongo.getCommand(command).then((commands) =>
+            {
+                if (commands.length > 0)
+                {
+                    audioCommand = commands[0];
+                    console.log(`Found audio command in mongo for !${command}`);
+                    isMongoCommand = true;
+                }
+            })
+        } 
 
         if (audioCommand)
         {

--- a/pbot.js
+++ b/pbot.js
@@ -186,7 +186,7 @@ client.on('message', (message) =>
             const emoji = getEmoji(audioCommand.emoji);
             message.react(emoji);
 
-            playAudioRaw(channel, audioCommand.path);
+            isMongoCommand ? playAudioFromMongo(channel, audioCommand.path) : playAudioRaw(channel, audioCommand.path);
         }
         else if (command === 'roll')
         {


### PR DESCRIPTION
Thinking schema similar to current commands:
`{ command: 'activate', path: 'assets/activate.mp3', emoji: 'mello' },`

path would be adjusted to match the mongo intro sound paths.